### PR TITLE
Handle reset correlation id case

### DIFF
--- a/src/protocol/ClientMessage.ts
+++ b/src/protocol/ClientMessage.ts
@@ -200,7 +200,24 @@ export class ClientMessage {
         return FixSizedTypesCodec.decodeNumberFromLong(this.startFrame.content, CORRELATION_ID_OFFSET);
     }
 
-    setCorrelationId(correlationId: any): void {
+    /**
+     * Resets correlation id to -1.
+     *
+     * Important note: after this call a proper (non-negative) correlation id
+     * must be set before sending the message to the cluster.
+     */
+    resetCorrelationId(): void {
+        this.startFrame.content.writeInt32LE(0xFFFFFFFF|0, CORRELATION_ID_OFFSET);
+        this.startFrame.content.writeInt32LE(0xFFFFFFFF|0, CORRELATION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES);
+    }
+
+    /**
+     * Sets correlation id for the message. The id must be a non-negative
+     * integer.
+     *
+     * @param correlationId correlation id
+     */
+    setCorrelationId(correlationId: number): void {
         FixSizedTypesCodec.encodeNonNegativeNumberAsLong(this.startFrame.content, CORRELATION_ID_OFFSET, correlationId);
     }
 
@@ -267,7 +284,7 @@ export class ClientMessage {
         const startFrameCopy = this.startFrame.deepCopy();
         const newMessage = new ClientMessage(startFrameCopy, this.endFrame);
 
-        newMessage.setCorrelationId(-1);
+        newMessage.resetCorrelationId();
         newMessage.retryable = this.retryable;
         return newMessage;
     }

--- a/test/unit/protocol/ClientMessageTest.js
+++ b/test/unit/protocol/ClientMessageTest.js
@@ -16,8 +16,7 @@
 
 'use strict';
 
-const expect = require('chai').expect;
-const Long = require('long');
+const { expect } = require('chai');
 
 const {
     ClientMessage,
@@ -49,7 +48,7 @@ describe('ClientMessageTest', function () {
 
         cmEncode.addFrame(Frame.createInitialFrame(50));
         cmEncode.setMessageType(1);
-        cmEncode.setCorrelationId(Long.fromString('1234567812345678'));
+        cmEncode.setCorrelationId(1234567812345678);
         cmEncode.setPartitionId(11223344);
 
         const cmDecode = ClientMessage.createForDecode(cmEncode.startFrame);
@@ -66,7 +65,7 @@ describe('ClientMessageTest', function () {
 
         originalMessage.addFrame(Frame.createInitialFrame(50));
         originalMessage.setMessageType(1);
-        originalMessage.setCorrelationId(Long.fromString('1234567812345678'));
+        originalMessage.setCorrelationId(1234567812345678);
         originalMessage.setPartitionId(11223344);
         originalMessage.setRetryable(true);
         originalMessage.addFrame(Frame.createInitialFrame(20));
@@ -126,7 +125,7 @@ describe('ClientMessageTest', function () {
         const frame1 = Frame.createInitialFrame(16);
         clientMessage.addFrame(frame1);
         clientMessage.setMessageType(1);
-        clientMessage.setCorrelationId(Long.fromString('123'));
+        clientMessage.setCorrelationId(123);
         clientMessage.setPartitionId(11223344);
 
         const frame2 = new Frame(Buffer.from('foo', 'utf8'));
@@ -154,7 +153,7 @@ describe('ClientMessageTest', function () {
         const frame = Frame.createInitialFrame(16);
         clientMessage.addFrame(frame);
         clientMessage.setMessageType(1);
-        clientMessage.setCorrelationId(Long.fromString('123'));
+        clientMessage.setCorrelationId(123);
         clientMessage.setPartitionId(11223344);
 
         const actual = clientMessage.toBuffer();


### PR DESCRIPTION
`-1` is used as an intermediate magic number when copying client messages. This PR adds proper handling for this case.

Alternatively, we could implement negative number handling in `FixSizedTypesCodec#encodeNonNegativeNumberAsLong`, but we don't really need that functionality except for the `-1` value.